### PR TITLE
request() - only var_dump($query) if verbose is enabled

### DIFF
--- a/src/SuperSaaS/Client.php
+++ b/src/SuperSaaS/Client.php
@@ -128,7 +128,9 @@ class Client
             throw new \Exception(new SSS_Exception("Invalid HTTP Method: " . $http_method . ". Only `GET`, `POST`, `PUT`, `DELETE` supported."));
         }
 
-        echo "\n\n".var_dump($query)."\n\n";
+        if ($this->verbose) {
+            echo "\n\n".var_dump($query)."\n\n";
+        }
 
         $url = $this->host . "/api" . $path . ".json";
         if (!empty($query)) {


### PR DESCRIPTION
Unless I've missed something, using the client without this change would produce unwanted output with every request, and possibly break your application?