### PR TITLE
Throw SSS_Exception rather than standard Exception

### DIFF
--- a/src/SuperSaaS/API/BaseApi.php
+++ b/src/SuperSaaS/API/BaseApi.php
@@ -22,7 +22,7 @@ class BaseApi
         } else if (preg_match(self::INTEGER_REGEX, $value)) {
             return intval($value);
         } else {
-            throw new \Exception(new SSS_Exception("Invalid id parameter: " . $value . ". Provide a integer value."));
+            throw new SSS_Exception("Invalid id parameter: " . $value . ". Provide a integer value.");
         }
     }
 
@@ -32,7 +32,7 @@ class BaseApi
 
     protected function validatePresent ($value) {
         if (empty($value)) {
-            throw new \Exception(new SSS_Exception("Required parameter is missing."));
+            throw new SSS_Exception("Required parameter is missing.");
         } else {
             return $value;
         }
@@ -44,7 +44,7 @@ class BaseApi
         } else if (preg_match(self::DATETIME_REGEX, $value.'')) {
             return $value;
         } else {
-            throw new \Exception(new SSS_Exception("Invalid datetime parameter: " . $value . ". Provide a DateTime object or formatted 'YYYY-DD-MM HH:MM:SS' string."));
+            throw new SSS_Exception("Invalid datetime parameter: " . $value . ". Provide a DateTime object or formatted 'YYYY-DD-MM HH:MM:SS' string.");
         }
     }
 
@@ -52,7 +52,7 @@ class BaseApi
         if (in_array($value, $options)) {
 
         } else {
-            throw new \Exception(new SSS_Exception("Invalid option parameter: " . $value . ". Must be one of " . join(', ', $options)));
+            throw new SSS_Exception("Invalid option parameter: " . $value . ". Must be one of " . join(', ', $options));
         }
     }
 }

--- a/src/SuperSaaS/Client.php
+++ b/src/SuperSaaS/Client.php
@@ -1,6 +1,8 @@
 <?php namespace SuperSaaS;
 
 use SuperSaaS\API;
+use SuperSaaS\SSS_Exception;
+
 
 class Client
 {
@@ -108,16 +110,16 @@ class Client
     }
 
     /**
-     * @throws \Exception
+     * @throws SSS_Exception
      */
     public function request ($http_method, $path, $params = array(), $query = array()) {
         if (empty($this->account_name))
         {
-            throw new \Exception(new SSS_Exception("Account name not configured. Call `SuperSaaS_Client.configure`."));
+            throw new SSS_Exception("Account name not configured. Call `SuperSaaS_Client.configure`.");
         }
         if (empty($this->api_key))
         {
-            throw new \Exception(new SSS_Exception("Account api key not configured. Call `SuperSaaS_Client.configure`."));
+            throw new SSS_Exception("Account api key not configured. Call `SuperSaaS_Client.configure`.");
         }
         $params = $this->removeEmptyKeys($params);
         $query = $this->removeEmptyKeys($query);
@@ -125,7 +127,7 @@ class Client
         $params['account_name'] = $this->account_name;
 
         if (!in_array($http_method, array("GET", "POST", "PUT", "DELETE"))) {
-            throw new \Exception(new SSS_Exception("Invalid HTTP Method: " . $http_method . ". Only `GET`, `POST`, `PUT`, `DELETE` supported."));
+            throw new SSS_Exception("Invalid HTTP Method: " . $http_method . ". Only `GET`, `POST`, `PUT`, `DELETE` supported.");
         }
 
         if ($this->verbose) {
@@ -175,7 +177,7 @@ class Client
                 echo($res."\n\r");
                 echo("==============================\n\r");
             }
-            throw new \Exception(new SSS_Exception("HTTP Request Error " . $url));
+            throw new SSS_Exception("HTTP Request Error " . $url);
         } else if (!empty($res)) {
             if ($this->verbose) {
                 echo("Response:\n\r");


### PR DESCRIPTION
Originally it throws a standard PHP `Exception`, using a new instance of `SSS_Exception` as the message, which makes the exception message include the entire stack trace.